### PR TITLE
Rename to redirect_url to redirect_uri

### DIFF
--- a/auth0_flutter_web/lib/src/options.dart
+++ b/auth0_flutter_web/lib/src/options.dart
@@ -48,7 +48,7 @@ class Auth0ClientOptions extends BaseLoginOptions {
   external String get domain;
   external String get issuer;
   external String get client_id;
-  external String get redirect_url;
+  external String get redirect_uri;
   external num get leeway;
   external Object get cacheLocation;
   external bool get useRefreshTokens;
@@ -72,7 +72,7 @@ class Auth0ClientOptions extends BaseLoginOptions {
     @required String domain,
     String issuer,
     @required String client_id,
-    String redirect_url,
+    String redirect_uri,
     num leeway,
     Object cacheLocation,
     bool useRefreshTokens,


### PR DESCRIPTION
According to the api docs the correct name for this option is `redirect_uri`.


Ref. https://github.com/auth0/auth0-spa-js/blob/master/src/global.ts#L132